### PR TITLE
Load use-package for using its symbol and function

### DIFF
--- a/use-package-chords.el
+++ b/use-package-chords.el
@@ -15,6 +15,7 @@
 
 ;;; Code:
 
+(require 'use-package)
 (require 'bind-key)
 (require 'key-chord)
 


### PR DESCRIPTION
There are some byte-compile warnings about this.

```
use-package-chords.el:58:15:Warning: reference to free variable
    `use-package-keywords'
use-package-chords.el:58:15:Warning: assignment to free variable
    `use-package-keywords'

In end of data:
use-package-chords.el:68:1:Warning: the function `use-package-handler/:bind'
    is not known to be defined.
```
