### PR TITLE
fix: Update bind-chord implementation

### DIFF
--- a/bind-chord.el
+++ b/bind-chord.el
@@ -5,7 +5,7 @@
 ;; Author: Justin Talbott <justin@waymondo.com>
 ;; Keywords: convenience, tools, extensions
 ;; URL: https://github.com/jwiegley/use-package
-;; Version: 0.2.1
+;; Version: 0.2.2
 ;; Package-Requires: ((emacs "24.3") (bind-key "1.0") (key-chord "0.6"))
 ;; Filename: bind-chord.el
 
@@ -28,17 +28,15 @@
 
 (require 'bind-key)
 (require 'key-chord nil t)
+(declare-function key-chord-define "key-chord" (keymap keys command))
 
 ;;;###autoload
 (defmacro bind-chord (chord command &optional keymap)
-  "Bind CHORD to COMMAND in KEYMAP (`global-map' if not passed)."
-  (let ((key1 (logand 255 (aref chord 0)))
-        (key2 (logand 255 (aref chord 1))))
-    (if (eq key1 key2)
-        `(bind-key (vector 'key-chord ,key1 ,key2) ,command ,keymap)
-      `(progn
-         (bind-key (vector 'key-chord ,key1 ,key2) ,command ,keymap)
-         (bind-key (vector 'key-chord ,key2 ,key1) ,command ,keymap)))))
+  "Bind CHORD to COMMAND in KEYMAP (`global-map' if not passed).
+CHORD must be a string (e.g., \"jk\") or a vector (e.g., [?j ?k])."
+  `(key-chord-define ,(if keymap keymap 'global-map)
+                     ,chord
+                     ,command))
 
 (defun bind-chords-form (args keymap)
   "Bind multiple chords at once.

--- a/use-package-chords.el
+++ b/use-package-chords.el
@@ -5,8 +5,8 @@
 ;; Author: Justin Talbott <justin@waymondo.com>
 ;; Keywords: convenience, tools, extensions
 ;; URL: https://github.com/jwiegley/use-package
-;; Version: 0.2.1
-;; Package-Requires: ((use-package "2.1") (bind-key "1.0") (bind-chord "0.2") (key-chord "0.6"))
+;; Version: 0.2.2
+;; Package-Requires: ((use-package "2.1") (bind-key "1.0") (bind-chord "0.2.2") (key-chord "0.6"))
 ;; Filename: use-package-chords.el
 
 ;; This program is free software; you can redistribute it and/or modify


### PR DESCRIPTION
Update bind-chord to use the key-chord-define instead of hacking the internal representation of a key-chord. This is because I am making deep changes to key-chord in https://github.com/emacsorphanage/key-chord/pull/12.